### PR TITLE
Async-i-fy the compiler (#1708)

### DIFF
--- a/lib/base-compiler.js
+++ b/lib/base-compiler.js
@@ -386,20 +386,20 @@ class BaseCompiler {
         return userOptions;
     }
 
-    generateAST(inputFilename, options) {
+    async generateAST(inputFilename, options) {
         // These options make Clang produce an AST dump
-        let newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
+        const newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
             .concat(["-Xclang", "-ast-dump", "-fsyntax-only"]);
 
-        let execOptions = this.getDefaultExecOptions();
+        const execOptions = this.getDefaultExecOptions();
         // A higher max output is needed for when the user includes headers
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
-        return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
-            .then(this.processAstOutput);
+        return this.processAstOutput(
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions));
     }
 
-    generateIR(inputFilename, options, filters) {
+    async generateIR(inputFilename, options, filters) {
         // These options make Clang produce an IR
         let newOptions = _.filter(options, option => option !== '-fcolor-diagnostics')
             .concat(this.compiler.irArg);
@@ -408,17 +408,15 @@ class BaseCompiler {
         // A higher max output is needed for when the user includes headers
         execOptions.maxOutput = 1024 * 1024 * 1024;
 
-        return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
-            .then((output) => {
-                const ir = this.processIrOutput(output, filters);
-                return ir.asm;
-            });
+        const output = this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions);
+        const ir = await this.processIrOutput(output, filters);
+        return ir.asm;
     }
 
-    processIrOutput(output, filters) {
+    async processIrOutput(output, filters) {
         const irPath = this.getIrOutputFilename(output.inputFilename);
-        if (fs.existsSync(irPath)) {
-            const output = fs.readFileSync(irPath, 'utf-8');
+        if (await fs.pathExists(irPath)) {
+            const output = await fs.readFile(irPath, 'utf-8');
             // uses same filters as main compiler
             return this.llvmIr.process(output, filters);
         }
@@ -616,11 +614,72 @@ class BaseCompiler {
         }
     }
 
-    compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries) {
+    async doCompilation(inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools) {
+        const inputFilenameSafe = this.filename(inputFilename);
+        const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
+
+        options = _.compact(
+            this.prepareArguments(options, filters, backendOptions,
+                inputFilename, outputFilename, libraries)
+        );
+
+        const execOptions = this.getDefaultExecOptions();
+        execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
+
+        const makeAst = backendOptions && backendOptions.produceAst && this.compiler.supportsAstView;
+        const makeIr = backendOptions && backendOptions.produceIr && this.compiler.supportsIrView;
+        const makeGccDump = backendOptions && backendOptions.produceGccDump
+            && backendOptions.produceGccDump.opened && this.compiler.supportsGccDump;
+
+        const [asmResult, astResult, gccDumpResult, irResult, toolsResult] = await Promise.all([
+            this.runCompiler(this.compiler.exe, options, inputFilenameSafe, execOptions),
+            (makeAst ? this.generateAST(inputFilename, options) : ""),
+            (makeGccDump ? this.generateGccDump(inputFilename, options, backendOptions.produceGccDump) : ""),
+            (makeIr ? this.generateIR(inputFilename, options, filters) : ""),
+            Promise.all(this.runToolsOfType(tools, "independent", this.getCompilationInfo(key, {
+                inputFilename,
+                dirPath,
+                outputFilename
+            })))
+        ]);
+        asmResult.dirPath = dirPath;
+        asmResult.compilationOptions = options;
+        // Here before the check to ensure dump reports even on failure cases
+        if (this.compiler.supportsGccDump && gccDumpResult) {
+            asmResult.gccDumpOutput = gccDumpResult;
+        }
+
+        asmResult.tools = toolsResult;
+
+        if (asmResult.code !== 0) {
+            asmResult.asm = "<Compilation failed>";
+            return [asmResult];
+        }
+
+        if (this.compiler.supportsOptOutput && this.optOutputRequested(options)) {
+            const optPath = path.join(dirPath, `${this.outputFilebase}.opt.yaml`);
+            if (await fs.pathExists(optPath)) {
+                asmResult.hasOptOutput = true;
+                asmResult.optPath = optPath;
+            }
+        }
+        if (astResult) {
+            asmResult.hasAstOutput = true;
+            asmResult.astOutput = astResult;
+        }
+        if (irResult) {
+            asmResult.hasIrOutput = true;
+            asmResult.irOutput = irResult;
+        }
+
+        return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);
+    }
+
+    async compile(source, options, backendOptions, filters, bypassCache, tools, executionParameters, libraries) {
         const optionsError = this.checkOptions(options);
-        if (optionsError) return Promise.reject(optionsError);
+        if (optionsError) throw optionsError;
         const sourceError = this.checkSource(source);
-        if (sourceError) return Promise.reject(sourceError);
+        if (sourceError) throw sourceError;
 
         const libsAndOptions = {libraries, options};
         if (this.tryAutodetectLibraries(libsAndOptions)) {
@@ -642,203 +701,75 @@ class BaseCompiler {
         filters = Object.assign({}, filters);
         filters.execute = false;
 
-        const cacheGet = bypassCache ? Promise.resolve(null) : this.env.cacheGet(key);
-        return cacheGet
-            .then((result) => {
-                if (result) {
-                    if (doExecute) {
-                        return this.handleExecution(key, executeParameters).then((execResult) => {
-                            result.execResult = execResult;
-
-                            return result;
-                        });
-                    }
-
-                    return result;
-                }
-
-                source = this.preProcess(source);
-                if (filters.binary && !source.match(this.compilerProps("stubRe"))) {
-                    source += "\n" + this.compilerProps("stubText") + "\n";
-                }
-                return this.env.enqueue(() => {
-                    const tempFileAndDirPromise = this.newTempDir()
-                        .then(async dirPath => {
-                            const inputFilename = path.join(dirPath, this.compileFilename);
-                            await fs.writeFile(inputFilename, source);
-                            return {
-                                inputFilename: inputFilename,
-                                dirPath: dirPath
-                            };
-                        });
-                    if (!backendOptions || !backendOptions.executorRequest) {
-                        const compileToAsmPromise = tempFileAndDirPromise.then(info => {
-                            const inputFilename = info.inputFilename;
-                            const inputFilenameSafe = this.filename(inputFilename);
-                            const dirPath = info.dirPath;
-                            const outputFilename = this.getOutputFilename(dirPath, this.outputFilebase);
-
-                            options = _.compact(
-                                this.prepareArguments(options, filters, backendOptions,
-                                    inputFilename, outputFilename, libraries)
-                            );
-
-                            const toolsPromise = this.runToolsOfType(tools, "independent",
-                                this.getCompilationInfo(key, {inputFilename, dirPath, outputFilename}));
-
-                            const execOptions = this.getDefaultExecOptions();
-                            execOptions.ldPath = this.getSharedLibraryPathsAsLdLibraryPaths(key.libraries);
-
-                            const asmPromise = this.runCompiler(this.compiler.exe, options, inputFilenameSafe,
-                                execOptions);
-
-                            let astPromise;
-                            if (backendOptions && backendOptions.produceAst && this.compiler.supportsAstView) {
-                                astPromise = this.generateAST(inputFilename, options);
-                            } else {
-                                astPromise = Promise.resolve("");
-                            }
-
-                            let irPromise;
-                            if (backendOptions && backendOptions.produceIr && this.compiler.supportsIrView) {
-                                irPromise = this.generateIR(inputFilename, options, filters);
-                            } else {
-                                irPromise = Promise.resolve("");
-                            }
-
-                            let gccDumpPromise;
-                            if (backendOptions && backendOptions.produceGccDump &&
-                                backendOptions.produceGccDump.opened && this.compiler.supportsGccDump) {
-
-                                gccDumpPromise = this.generateGccDump(
-                                    inputFilename, options, backendOptions.produceGccDump);
-                            } else {
-                                gccDumpPromise = Promise.resolve("");
-                            }
-
-                            return Promise.all([
-                                asmPromise,
-                                astPromise,
-                                gccDumpPromise,
-                                irPromise,
-                                Promise.all(toolsPromise)
-                            ])
-                                .then(([asmResult, astResult, gccDumpResult, irResult, toolsPromise]) => {
-                                    asmResult.dirPath = dirPath;
-                                    asmResult.compilationOptions = options;
-                                    // Here before the check to ensure dump reports even on failure cases
-                                    if (this.compiler.supportsGccDump && gccDumpResult) {
-                                        asmResult.gccDumpOutput = gccDumpResult;
-                                    }
-
-                                    asmResult.tools = toolsPromise;
-
-                                    if (asmResult.code !== 0) {
-                                        asmResult.asm = "<Compilation failed>";
-                                        return asmResult;
-                                    }
-
-                                    if (this.compiler.supportsOptOutput && this.optOutputRequested(options)) {
-                                        const optPath = path.join(dirPath, `${this.outputFilebase}.opt.yaml`);
-                                        if (fs.existsSync(optPath)) {
-                                            asmResult.hasOptOutput = true;
-                                            asmResult.optPath = optPath;
-                                        }
-                                    }
-                                    if (astResult) {
-                                        asmResult.hasAstOutput = true;
-                                        asmResult.astOutput = astResult;
-                                    }
-                                    if (irResult) {
-                                        asmResult.hasIrOutput = true;
-                                        asmResult.irOutput = irResult;
-                                    }
-
-                                    return this.checkOutputFileAndDoPostProcess(asmResult, outputFilename, filters);
-                                });
-                        });
-
-                        let executionPromise;
-
-                        return compileToAsmPromise
-                            .then(results => {
-                                let optOutput;
-                                let result;
-                                if (results.length) {
-                                    result = results[0];
-                                    optOutput = results[1];
-                                } else {
-                                    result = results;
-                                }
-                                if (result.hasOptOutput) {
-                                    delete result.optPath;
-                                    result.optOutput = optOutput;
-                                }
-                                return result;
-                            })
-                            .then(result => {
-                                if (doExecute) {
-                                    executionPromise = this.handleExecution(key, executeParameters);
-                                } else {
-                                    executionPromise = Promise.resolve(false);
-                                }
-                                return result;
-                            })
-                            .then(result => {
-                                const postToolsPromise = this.runToolsOfType(tools, "postcompilation",
-                                    this.getCompilationInfo(key, result));
-
-                                return Promise.all([Promise.all(postToolsPromise)]).then(([postToolsResult]) => {
-                                    result.tools = _.union(result.tools, postToolsResult);
-
-                                    return result;
-                                });
-                            })
-                            .then(result => {
-                                if (result.dirPath) {
-                                    fs.remove(result.dirPath);
-                                    result.dirPath = undefined;
-                                }
-                                if (result.okToCache) {
-                                    const res = this.processAsm(result, filters);
-                                    result.asm = res.asm;
-                                    result.labelDefinitions = res.labelDefinitions;
-                                } else {
-                                    result.asm = [{text: result.asm}];
-                                }
-                                return result;
-                            })
-                            .then(result => filters.demangle ? this.postProcessAsm(result, filters) : result)
-                            .then(result => {
-                                if (this.compiler.supportsCfg && backendOptions && backendOptions.produceCfg) {
-                                    result.cfg = cfg.generateStructure(this.compiler.compilerType,
-                                        this.compiler.version, result.asm);
-                                }
-                                return result;
-                            })
-                            .then(result => {
-                                result.popularArguments = this.possibleArguments.getPopularArguments(options);
-
-                                return result;
-                            })
-                            .then(result => {
-                                if (result.okToCache) {
-                                    this.env.cachePut(key, result);
-                                }
-
-                                return Promise.all([executionPromise]).then(([executionResult]) => {
-                                    if (executionResult) {
-                                        result.execResult = executionResult;
-                                    }
-
-                                    return result;
-                                });
-                            });
-                    } else {
+        if (!bypassCache) {
+            const result = await this.env.cacheGet(key);
+            if (result) {
+                if (doExecute) {
+                    result.execResult = await this.env.enqueue(async () => {
                         return this.handleExecution(key, executeParameters);
-                    }
+                    });
+                }
+                return result;
+            }
+        }
+
+        return this.env.enqueue(async () => {
+            source = this.preProcess(source);
+            if (filters.binary && !source.match(this.compilerProps("stubRe"))) {
+                source += "\n" + this.compilerProps("stubText") + "\n";
+            }
+
+            if (backendOptions && backendOptions.executorRequest) {
+                return this.handleExecution(key, executeParameters);
+            }
+
+            const dirPath = await this.newTempDir();
+            const inputFilename = path.join(dirPath, this.compileFilename);
+            await fs.writeFile(inputFilename, source);
+
+            // TODO make const when I can
+            let [result, optOutput] = await this.doCompilation(
+                inputFilename, dirPath, key, options, filters, backendOptions, libraries, tools);
+
+            // Start the execution as soon as we can, but only await it at the end.
+            const execPromise = doExecute ? this.handleExecution(key, executeParameters) : null;
+
+            if (result.hasOptOutput) {
+                delete result.optPath;
+                result.optOutput = optOutput;
+            }
+            result.tools = _.union(result.tools, await Promise.all(this.runToolsOfType(tools, "postcompilation",
+                this.getCompilationInfo(key, result))));
+            if (result.dirPath) {
+                fs.remove(result.dirPath);
+                result.dirPath = undefined;
+            }
+            if (result.okToCache) {
+                const res = this.processAsm(result, filters);
+                result.asm = res.asm;
+                result.labelDefinitions = res.labelDefinitions;
+            } else {
+                result.asm = [{text: result.asm}];
+            }
+            // TODO rephrase this so we don't need to reassign
+            result = filters.demangle ? await this.postProcessAsm(result, filters) : result;
+            if (this.compiler.supportsCfg && backendOptions && backendOptions.produceCfg) {
+                result.cfg = cfg.generateStructure(this.compiler.compilerType,
+                    this.compiler.version, result.asm);
+            }
+            result.popularArguments = this.possibleArguments.getPopularArguments(options);
+            if (result.okToCache) {
+                this.env.cachePut(key, result).then(() => {
+                    // purely here to ensure the cache put happens (if it's not "then"-ned it might not start. as it
+                    // happens it does cos internally to cachePut it "catch"-es. but I don't want to rely on this.
                 });
-            });
+            }
+
+            if (doExecute) {
+                result.execResult = await execPromise;
+            }
+            return result;
+        });
     }
 
     processAsm(result, filters) {
@@ -848,7 +779,7 @@ class BaseCompiler {
         return this.asm.process(result.asm, filters);
     }
 
-    postProcessAsm(result) {
+    async postProcessAsm(result) {
         if (!result.okToCache || !this.demanglerClass || !result.asm) return result;
         const demangler = new this.demanglerClass(this.compiler.demangler, this);
         return demangler.process(result);
@@ -988,7 +919,7 @@ class BaseCompiler {
         if (opts.pass) {
             const passDump = `${result.inputFilename}.${opts.pass}`;
 
-            if (fs.existsSync(passDump) && (await fs.stat(passDump)).isFile()) {
+            if (await fs.pathExists(passDump) && (await fs.stat(passDump)).isFile()) {
                 output.currentPassOutput = await fs.readFile(passDump, 'utf-8');
                 if (output.currentPassOutput.match(/^\s*$/)) {
                     output.currentPassOutput = 'File for selected pass is empty.';

--- a/lib/compilers/ldc.js
+++ b/lib/compilers/ldc.js
@@ -66,26 +66,30 @@ class LDCCompiler extends BaseCompiler {
         return versionMatch ? semverParser.compare(versionMatch[1] + ".0", "1.4.0") >= 0 : false;
     }
 
-    generateAST(inputFilename, options) {
+    async generateAST(inputFilename, options) {
         // These options make LDC produce an AST dump in a separate file `<inputFilename>.cg`.
-        let newOptions = options.concat("-vcg-ast");
-        let execOptions = this.getDefaultExecOptions();
-        return this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions)
-            .then(this.loadASTOutput);
+        const newOptions = options.concat("-vcg-ast");
+        const execOptions = this.getDefaultExecOptions();
+        return this.loadASTOutput(
+            await this.runCompiler(this.compiler.exe, newOptions, this.filename(inputFilename), execOptions));
     }
 
-    loadASTOutput(output) {
+    async loadASTOutput(output) {
         if (output.code !== 0) {
             return `Error generating AST: ${output.code}`;
         }
         // Load the AST output from the `.cg` file.
         // Demangling is not needed.
         const astFilename = output.inputFilename.concat(".cg");
-        if (!fs.existsSync(astFilename)) {
-            logger.warn(`LDC AST file ${astFilename} requested but it does not exist`);
-            return "";
+        try {
+            return await fs.readFile(astFilename, 'utf-8');
+        } catch (e) {
+            if (e instanceof Error && e.code === 'ENOENT') {
+                logger.warn(`LDC AST file ${astFilename} requested but it does not exist`);
+                return "";
+            }
+            throw e;
         }
-        return fs.readFileSync(astFilename, 'utf-8');
     }
 
     // Override the IR file name method for LDC because the output file is different from clang.

--- a/lib/demangler-pascal.js
+++ b/lib/demangler-pascal.js
@@ -84,7 +84,7 @@ class DemanglerPascal extends Demangler {
 
         text = text.substr(0, text.length - 1);
 
-        for (let k in this.fixedsymbols) {
+        for (const k in this.fixedsymbols) {
             if (text === k) {
                 text = text.replace(k, this.fixedsymbols[k]);
                 this.symbolStore.add(k, this.fixedsymbols[k]);
@@ -93,11 +93,11 @@ class DemanglerPascal extends Demangler {
         }
 
         if (text.startsWith("U_$OUTPUT_$$_")) {
-            let unmangledGlobalVar = text.substr(13).toLowerCase();
+            const unmangledGlobalVar = text.substr(13).toLowerCase();
             this.symbolStore.add(text, unmangledGlobalVar);
             return unmangledGlobalVar;
         } else if (text.startsWith("U_OUTPUT_")) {
-            let unmangledGlobalVar = text.substr(9).toLowerCase();
+            const unmangledGlobalVar = text.substr(9).toLowerCase();
             this.symbolStore.add(text, unmangledGlobalVar);
             return unmangledGlobalVar;
         }
@@ -177,7 +177,7 @@ class DemanglerPascal extends Demangler {
             }
 
             const translations = this.symbolStore.listTranslations();
-            for (let idx in translations) {
+            for (const idx in translations) {
                 text = text.replace(translations[idx][0], translations[idx][1]);
             }
 
@@ -187,7 +187,7 @@ class DemanglerPascal extends Demangler {
         }
     }
 
-    process(result, execOptions) {
+    async process(result, execOptions) {
         let options = execOptions || {};
         this.result = result;
 

--- a/lib/demangler-win32.js
+++ b/lib/demangler-win32.js
@@ -70,7 +70,7 @@ class DemanglerWin32 extends DemanglerCPP {
                     ? asmLine.text.match(this.allDecoratedLabelsWithQuotes)
                     : asmLine.text.match(this.allDecoratedLabels);
             if (labels) {
-                let [ , beforeComment, afterComment] = asmLine.text.match(/(.*)(;.*)?/);
+                let [, beforeComment, afterComment] = asmLine.text.match(/(.*)(;.*)?/);
                 for (const label of labels) {
                     const replacement = translations[label];
                     if (replacement) {
@@ -90,7 +90,7 @@ class DemanglerWin32 extends DemanglerCPP {
         let translations = {};
 
         const demangleSingleSet = names => {
-            const args = [this.flags, ... names];
+            const args = [this.flags, ...names];
             return this.compiler.exec(this.demanglerExe, args, this.compiler.getDefaultExecOptions())
                 .then(output => {
                     const outputArray = utils.splitLines(output.stdout);
@@ -147,16 +147,16 @@ class DemanglerWin32 extends DemanglerCPP {
         return Promise.all(demangleAllArgs).then(() => translations);
     }
 
-    process(result) {
+    async process(result) {
         if (!this.demanglerExe) {
             logger.error("Attempted to demangle, but there's no demangler set");
-            return Promise.resolve(result);
+            return result;
         }
 
         this.result = result;
 
         this.collectLabels();
-        return this.execDemangler().then(output => this.processOutput(output));
+        return this.processOutput(await this.execDemangler());
     }
 }
 

--- a/lib/demangler.js
+++ b/lib/demangler.js
@@ -131,14 +131,8 @@ class Demangler extends AsmRegex {
         return this.input.join("\n");
     }
 
-    /**
-     *
-     * @param {string} symbol
-     */
     getMetadata() {
-        let metadata = [];
-
-        return metadata;
+        return [];
     }
 
     /**
@@ -206,7 +200,7 @@ class Demangler extends AsmRegex {
         );
     }
 
-    process(result, execOptions) {
+    async process(result, execOptions) {
         let options = execOptions || {};
         this.result = result;
 
@@ -218,10 +212,9 @@ class Demangler extends AsmRegex {
         options.input = this.getInput();
 
         if (options.input === "") {
-            return new Promise((resolve) => resolve(this.result));
-        } else {
-            return this.execDemangler(options).then((output) => this.processOutput(output));
+            return this.result;
         }
+        return this.processOutput(await this.execDemangler(options));
     }
 }
 


### PR DESCRIPTION
Async-ify base-compiler

* Adds async to a number of methods
* Breaks 'compile' into a few smaller methods for readability
* Remove a few (seemingly!) unnecessary `Promise.all([x])`

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
