### PR TITLE
Use /efs/.health directly to avoid the need for a bind mount file

### DIFF
--- a/etc/config/compiler-explorer.amazon.properties
+++ b/etc/config/compiler-explorer.amazon.properties
@@ -21,7 +21,7 @@ formatter.clangformat.exe=/opt/compiler-explorer/clang-trunk/bin/clang-format
 formatter.clangformat.styles=Google:LLVM:Mozilla:Chromium:WebKit
 motdUrl=/motd/motd-prod.json
 storageSolution=s3
-healthCheckFilePath=/opt/.health
+healthCheckFilePath=/efs/.health
 
 eventLoopMeasureIntervalMs=50
 eventLoopLagThresholdWarn=100


### PR DESCRIPTION
<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
