### PR TITLE
New ARM compilers

### DIFF
--- a/etc/config/c++.amazon.properties
+++ b/etc/config/c++.amazon.properties
@@ -668,22 +668,21 @@ compiler.ppc64leclang.supportsBinary=false
 
 ###############################
 # GCC for ARM
-group.gccarm.compilers=armg454:armg464:aarchg54:armhfg54:arm541:armg630:arm710:arm64g630:armg640:armg730:armg820:arm64g640:arm64g730:arm64g820:armce820:arm831:arm921:arm1021
-group.gccarm.groupName=ARM GCC
-group.gccarm.isSemVer=true
-# Some of the compiler don't like -isystem (as they assume the code must be C).
+group.gccarm.compilers=&gcc32arm:&gcc64arm
+# Some of the compilers don't like -isystem (as they assume the code must be C).
 # See https://github.com/compiler-explorer/compiler-explorer/issues/989 for discussion/
 group.gccarm.includeFlag=-I
-compiler.aarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
-compiler.aarchg54.name=ARM64 gcc 5.4 (linux)
-compiler.aarchg54.alias=aarchg48
-compiler.aarchg54.semver=5.4
-compiler.aarchg54.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
+
+# 32 bit
+group.gcc32arm.groupName=Arm 32-bit GCC
+group.gcc32arm.compilers=armhfg54:arm541:armg454:armg464:armg630:arm710:armg640:armg730:armg820:armce820:arm831:arm921:arm930:arm1020:arm1021
+group.gcc32arm.isSemVer=true
+group.gcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+
 compiler.armhfg54.exe=/opt/compiler-explorer/arm/gcc-5.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
 compiler.armhfg54.name=ARM gcc 5.4 (linux)
 compiler.armhfg54.alias=armhfg482
 compiler.armhfg54.semver=5.4
-compiler.armhfg54.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.arm541.exe=/opt/compiler-explorer/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-g++
 compiler.arm541.name=ARM gcc 5.4.1 (none)
 compiler.arm541.semver=5.4.1
@@ -692,48 +691,26 @@ compiler.armg454.exe=/opt/compiler-explorer/arm/gcc-4.5.4/bin/arm-unknown-linux-
 compiler.armg454.alias=armg453
 compiler.armg454.name=ARM gcc 4.5.4 (linux)
 compiler.armg454.semver=4.5.4
-compiler.armg454.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg464.exe=/opt/compiler-explorer/arm/gcc-4.6.4/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg464.alias=armg463:/usr/bin/arm-linux-gnueabi-g++-4.6
 compiler.armg464.name=ARM gcc 4.6.4 (linux)
 compiler.armg464.semver=4.6.4
-compiler.armg464.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg630.exe=/opt/compiler-explorer/arm/gcc-6.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
 compiler.armg630.name=ARM gcc 6.3.0 (linux)
 compiler.armg630.semver=6.3.0
-compiler.armg630.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.arm710.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-g++
 compiler.arm710.name=ARM gcc 7.2.1 (none)
 compiler.arm710.semver=7.2.1
 compiler.arm710.supportsBinary=false
-compiler.arm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
-compiler.arm64g630.name=ARM64 gcc 6.3.0 (linux)
-compiler.arm64g630.semver=6.3.0
-compiler.arm64g630.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.armg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg640.name=ARM gcc 6.4
+compiler.armg640.name=ARM gcc 6.4 (linux)
 compiler.armg640.semver=6.4.0
-compiler.armg640.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg730.name=ARM gcc 7.3
+compiler.armg730.name=ARM gcc 7.3 (linux)
 compiler.armg730.semver=7.3.0
-compiler.armg730.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
 compiler.armg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-g++
-compiler.armg820.name=ARM gcc 8.2
+compiler.armg820.name=ARM gcc 8.2 (linux)
 compiler.armg820.semver=8.2.0
-compiler.armg820.objdumper=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-objdump
-compiler.arm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g640.name=ARM64 gcc 6.4
-compiler.arm64g640.semver=6.4.0
-compiler.arm64g640.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
-compiler.arm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g730.name=ARM64 gcc 7.3
-compiler.arm64g730.semver=7.3.0
-compiler.arm64g730.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
-compiler.arm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
-compiler.arm64g820.name=ARM64 gcc 8.2
-compiler.arm64g820.semver=8.2.0
-compiler.arm64g820.objdumper=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-objdump
 compiler.armce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-g++
 compiler.armce820.name=ARM gcc 8.2 (WinCE)
 compiler.armce820.semver=8.2.0
@@ -750,6 +727,41 @@ compiler.arm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-maj
 compiler.arm1021.name=ARM gcc 10.2.1 (none)
 compiler.arm1021.semver=10.2.1
 compiler.arm1021.supportsBinary=false
+compiler.arm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm930.name=ARM gcc 9.3 (linux)
+compiler.arm930.semver=9.3.0
+compiler.arm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-g++
+compiler.arm1020.name=ARM gcc 10.2 (linux)
+compiler.arm1020.semver=10.2.0
+
+# 64 bit
+group.gcc64arm.groupName=Arm 64-bit GCC
+group.gcc64arm.compilers=aarchg54:arm64g630:arm64g640:arm64g730:arm64g820:arm64g930:arm64g1020
+group.gcc64arm.isSemVer=true
+group.gcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+
+compiler.aarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
+compiler.aarchg54.name=ARM64 gcc 5.4
+compiler.aarchg54.alias=aarchg48
+compiler.aarchg54.semver=5.4
+compiler.arm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-g++
+compiler.arm64g630.name=ARM64 gcc 6.3
+compiler.arm64g630.semver=6.3
+compiler.arm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g640.name=ARM64 gcc 6.4
+compiler.arm64g640.semver=6.4.0
+compiler.arm64g730.exe=/opt/compiler-explorer/arm64/gcc-7.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g730.name=ARM64 gcc 7.3
+compiler.arm64g730.semver=7.3.0
+compiler.arm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g820.name=ARM64 gcc 8.2
+compiler.arm64g820.semver=8.2.0
+compiler.arm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g930.name=ARM64 gcc 9.3
+compiler.arm64g930.semver=9.3.0
+compiler.arm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-g++
+compiler.arm64g1020.name=ARM64 gcc 10.2
+compiler.arm64g1020.semver=10.2.0
 
 ###############################
 # GCC for Kalray

--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -536,21 +536,25 @@ compiler.cppc64leg630.semver=6.3.0
 
 ###############################
 # GCC for ARM
-group.cgccarm.compilers=carmg454:carmg464:caarchg54:carmhfg54:carm541:carmg630:carm710:carm64g630:carmg640:carmg730:carmg820:carm64g640:carm64g730:carm64g820:carmce820:carm831:carm921:carm1021
-group.cgccarm.groupName=ARM GCC
-group.cgccarm.isSemVer=true
-# Some of the compiler don't like -isystem (as they assume the code must be C).
+group.cgccarm.compilers=&cgcc32arm:&cgcc64arm
+group.cgccarm.supportsBinary=true
+# Some of the compilers don't like -isystem (as they assume the code must be C).
 # See https://github.com/compiler-explorer/compiler-explorer/issues/989 for discussion/
-group.gccarm.includeFlag=-I
-compiler.caarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
-compiler.caarchg54.name=ARM64 gcc 5.4 (linux)
-compiler.caarchg54.semver=5.4
+group.cgccarm.includeFlag=-I
+
+# 32 bit
+group.cgcc32arm.groupName=Arm 32-bit GCC
+group.cgcc32arm.compilers=carmhfg54:carm541:carmg454:carmg464:carmg630:carm710:carmg640:carmg730:carmg820:carmce820:carm831:carm921:carm930:carm1020:carm1021
+group.cgcc32arm.isSemVer=true
+group.cgcc32arm.objdumper=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-objdump
+
 compiler.carmhfg54.exe=/opt/compiler-explorer/arm/gcc-5.4.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
 compiler.carmhfg54.name=ARM gcc 5.4 (linux)
 compiler.carmhfg54.semver=5.4
 compiler.carm541.exe=/opt/compiler-explorer/gcc-arm-none-eabi-5_4-2016q3/bin/arm-none-eabi-gcc
 compiler.carm541.name=ARM gcc 5.4.1 (none)
 compiler.carm541.semver=5.4.1
+compiler.carm541.supportsBinary=false
 compiler.carmg454.exe=/opt/compiler-explorer/arm/gcc-4.5.4/bin/arm-unknown-linux-gnueabi-gcc
 compiler.carmg454.name=ARM gcc 4.5.4 (linux)
 compiler.carmg454.semver=4.5.4
@@ -563,18 +567,51 @@ compiler.carmg630.semver=6.3.0
 compiler.carm710.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-7-2017-q4-major/bin/arm-none-eabi-gcc
 compiler.carm710.name=ARM gcc 7.2.1 (none)
 compiler.carm710.semver=7.2.1
-compiler.carm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
-compiler.carm64g630.name=ARM64 gcc 6.3.0 (linux)
-compiler.carm64g630.semver=6.3.0
+compiler.carm710.supportsBinary=false
 compiler.carmg640.exe=/opt/compiler-explorer/arm/gcc-6.4.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
-compiler.carmg640.name=ARM gcc 6.4
+compiler.carmg640.name=ARM gcc 6.4 (linux)
 compiler.carmg640.semver=6.4.0
 compiler.carmg730.exe=/opt/compiler-explorer/arm/gcc-7.3.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
-compiler.carmg730.name=ARM gcc 7.3
+compiler.carmg730.name=ARM gcc 7.3 (linux)
 compiler.carmg730.semver=7.3.0
 compiler.carmg820.exe=/opt/compiler-explorer/arm/gcc-8.2.0/arm-unknown-linux-gnueabi/bin/arm-unknown-linux-gnueabi-gcc
-compiler.carmg820.name=ARM gcc 8.2
+compiler.carmg820.name=ARM gcc 8.2 (linux)
 compiler.carmg820.semver=8.2.0
+compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
+compiler.carmce820.name=ARM gcc 8.2 (WinCE)
+compiler.carmce820.semver=8.2.0
+compiler.carmce820.supportsBinary=false
+compiler.carm831.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-8-2019-q3-update/bin/arm-none-eabi-gcc
+compiler.carm831.name=ARM gcc 8.3.1 (none)
+compiler.carm831.semver=8.3.1
+compiler.carm831.supportsBinary=false
+compiler.carm921.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc
+compiler.carm921.name=ARM gcc 9.2.1 (none)
+compiler.carm921.semver=9.2.1
+compiler.carm921.supportsBinary=false
+compiler.carm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-gcc
+compiler.carm1021.name=ARM gcc 10.2.1 (none)
+compiler.carm1021.semver=10.2.1
+compiler.carm1021.supportsBinary=false
+compiler.carm930.exe=/opt/compiler-explorer/arm/gcc-9.3.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carm930.name=ARM gcc 9.3 (linux)
+compiler.carm930.semver=9.3.0
+compiler.carm1020.exe=/opt/compiler-explorer/arm/gcc-10.2.0/arm-unknown-linux-gnueabihf/bin/arm-unknown-linux-gnueabihf-gcc
+compiler.carm1020.name=ARM gcc 10.2 (linux)
+compiler.carm1020.semver=10.2.0
+
+# 64 bit
+group.cgcc64arm.groupName=Arm 64-bit GCC
+group.cgcc64arm.compilers=caarchg54:carm64g630:carm64g640:carm64g730:carm64g820:carm64g930:carm64g1020
+group.cgcc64arm.isSemVer=true
+group.cgcc64arm.objdumper=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/aarch64-unknown-linux-gnu/bin/objdump
+
+compiler.caarchg54.exe=/opt/compiler-explorer/arm64/gcc-5.4.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
+compiler.caarchg54.name=ARM64 gcc 5.4
+compiler.caarchg54.semver=5.4
+compiler.carm64g630.exe=/opt/compiler-explorer/arm64/gcc-6.3.0/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-gcc
+compiler.carm64g630.name=ARM64 gcc 6.3
+compiler.carm64g630.semver=6.3
 compiler.carm64g640.exe=/opt/compiler-explorer/arm64/gcc-6.4.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g640.name=ARM64 gcc 6.4
 compiler.carm64g640.semver=6.4.0
@@ -584,18 +621,12 @@ compiler.carm64g730.semver=7.3.0
 compiler.carm64g820.exe=/opt/compiler-explorer/arm64/gcc-8.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
 compiler.carm64g820.name=ARM64 gcc 8.2
 compiler.carm64g820.semver=8.2.0
-compiler.carmce820.exe=/opt/compiler-explorer/arm-wince/gcc-ce-8.2.0/bin/arm-mingw32ce-gcc
-compiler.carmce820.name=ARM gcc 8.2 (WinCE)
-compiler.carmce820.semver=8.2.0
-compiler.carm831.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-8-2019-q3-update/bin/arm-none-eabi-gcc
-compiler.carm831.name=ARM gcc 8.3.1 (none)
-compiler.carm831.semver=8.3.1
-compiler.carm921.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gcc
-compiler.carm921.name=ARM gcc 9.2.1 (none)
-compiler.carm921.semver=9.2.1
-compiler.carm1021.exe=/opt/compiler-explorer/arm/gcc-arm-none-eabi-10-2020-q4-major/bin/arm-none-eabi-gcc
-compiler.carm1021.name=ARM gcc 10.2.1 (none)
-compiler.carm1021.semver=10.2.1
+compiler.carm64g930.exe=/opt/compiler-explorer/arm64/gcc-9.3.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g930.name=ARM64 gcc 9.3
+compiler.carm64g930.semver=9.3.0
+compiler.carm64g1020.exe=/opt/compiler-explorer/arm64/gcc-10.2.0/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc
+compiler.carm64g1020.name=ARM64 gcc 10.2
+compiler.carm64g1020.semver=10.2.0
 
 ###############################
 # GCC for Kalray


### PR DESCRIPTION
* Add 9.3 and 10.2 ARM32 and ARM64 compilers
* Restructure the config and layout, separating
  groups of 32-bit and 64-bit ARM gcc compilers (Closes #2445)
* Enables binary support on a bunch more ARM compilers (including C)

CC @TamarChristinaArm @MattPD

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
