### PR TITLE
Support cproc C11 compiler (#2787)

### DIFF
--- a/etc/config/c.amazon.properties
+++ b/etc/config/c.amazon.properties
@@ -1,4 +1,4 @@
-compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc
+compilers=&cgcc86:&cclang:&armcclang32:&armcclang64:&rvcclang:&wasmcclang:&ppci:&cicc:&cicx:&ccl:&ccross:&cgcc-classic:&cc65:&sdcc:&ctendra:&tinycc:&zigcc:&cproc86
 defaultCompiler=cg111
 demangler=/opt/compiler-explorer/gcc-11.1.0/bin/c++filt
 objdumper=/opt/compiler-explorer/gcc-11.1.0/bin/objdump
@@ -1023,6 +1023,11 @@ compiler.zcc080.semver=0.8.0
 compiler.zcctrunk.exe=/opt/compiler-explorer/zig-master/zig
 compiler.zcctrunk.semver=trunk
 
+################################
+# cproc x86 compiler
+group.cproc86.compilers=cproc-master
+group.cproc86.instructionSet=amd64
+compiler.cproc-master.exe=/opt/compiler-explorer/cproc-master/bin/cproc
 
 #################################
 #################################

--- a/lib/compilers/_all.js
+++ b/lib/compilers/_all.js
@@ -31,6 +31,7 @@ export { ClangCompiler } from './clang';
 export { ClangCudaCompiler } from './clang';
 export { ClangHipCompiler } from './clang';
 export { CleanCompiler } from './clean';
+export { CprocCompiler } from './cproc';
 export { CrystalCompiler } from './crystal';
 export { DefaultCompiler } from './default';
 export { DMDCompiler } from './dmd';

--- a/lib/compilers/cproc.js
+++ b/lib/compilers/cproc.js
@@ -1,0 +1,40 @@
+// Copyright (c) 2021, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+import path from 'path';
+
+import { BaseCompiler } from '../base-compiler';
+
+export class CprocCompiler extends BaseCompiler {
+    static get key() { return 'cproc'; }
+
+    getDefaultExecOptions() {
+        const execOptions = super.getDefaultExecOptions();
+
+        // needed for finding the qbe program
+        let toolroot = path.resolve(path.dirname(this.compiler.exe));
+        execOptions.env.PATH = execOptions.env.PATH + ':' + toolroot;
+        return execOptions;
+    }
+}


### PR DESCRIPTION
Add support for cproc C11 compiler.
cproc is a lightweight compiler using the QBE backend.

Fixes #2755

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
