### PR TITLE
Re-enable tests for JavaCompiler (#2797)

### DIFF
--- a/test/java-tests.js
+++ b/test/java-tests.js
@@ -22,7 +22,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-import { JavaCompiler } from '../lib/compilers/java';
+import { JavaCompiler } from '../lib/compilers';
 import * as utils from '../lib/utils';
 
 import { fs, makeCompilationEnvironment } from './utils';
@@ -37,8 +37,7 @@ const info = {
     lang: languages.java.id,
 };
 
-// Temporarily disabled: see #1438
-describe.skip('Basic compiler setup', function () {
+describe('Basic compiler setup', function () {
     let env;
 
     before(() => {
@@ -60,7 +59,7 @@ describe.skip('Basic compiler setup', function () {
         }
     });
 
-    describe.skip('Forbidden compiler arguments', function () {
+    describe('Forbidden compiler arguments', function () {
         it('JavaCompiler should not allow -d parameter', () => {
             const compiler = new JavaCompiler(info, env);
             compiler.filterUserOptions(['hello', '-d', '--something', '--something-else']).should.deep.equal(
@@ -115,11 +114,11 @@ describe.skip('Basic compiler setup', function () {
     });
 });
 
-describe.skip('javap parsing', () => {
+describe('javap parsing', () => {
     let compiler;
     let env;
     before(() => {
-        const env = makeCompilationEnvironment({languages});
+        env = makeCompilationEnvironment({languages});
         compiler = new JavaCompiler(info, env);
     });
 


### PR DESCRIPTION
Now that Java is running on CE again, it'd make sense to re-enable these tests. This patch also includes a fix for the javap parsing test.

The local compilation environment variable was never set, causing env to be undefined inside testJava

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
