### PR TITLE
Add rustfmt as code formatting tool for Rust (#2798)

### DIFF
--- a/etc/config/rust.amazon.properties
+++ b/etc/config/rust.amazon.properties
@@ -153,7 +153,7 @@ libs=
 #################################
 # Installed tools
 
-tools=llvm-mcatrunk:osacatrunk
+tools=llvm-mcatrunk:osacatrunk:rustfmt1436
 
 tools.llvm-mcatrunk.name=llvm-mca (trunk)
 tools.llvm-mcatrunk.exe=/opt/compiler-explorer/clang-trunk/bin/llvm-mca
@@ -166,3 +166,11 @@ tools.osacatrunk.exe=/opt/compiler-explorer/osaca-0.4.5/bin/osaca
 tools.osacatrunk.type=postcompilation
 tools.osacatrunk.class=osaca-tool
 tools.osacatrunk.stdinHint=disabled
+
+tools.rustfmt1436.name=rustfmt (1.4.36)
+tools.rustfmt1436.exe=/opt/compiler-explorer/rustfmt-1.4.36/rustfmt
+tools.rustfmt1436.type=independent
+tools.rustfmt1436.class=rustfmt-tool
+tools.rustfmt1436.stdinHint=disabled
+tools.rustfmt1436.languageId=rust
+tools.rustfmt1436.options=--emit stdout

--- a/lib/tooling/rustfmt-tool.js
+++ b/lib/tooling/rustfmt-tool.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, Compiler Explorer Authors
+// Copyright (c) 2021, Compiler Explorer Authors
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -22,15 +22,19 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-export { ClangFormatTool } from './clang-format-tool';
-export { ClangQueryTool } from './clang-query-tool';
-export { ClangTidyTool } from './clang-tidy-tool';
-export { CompilerDropinTool } from './compiler-dropin-tool';
-export { LLVMMcaTool } from './llvm-mca-tool';
-export { OSACATool } from './osaca-tool';
-export { PaholeTool } from './pahole-tool';
-export { PvsStudioTool } from './pvs-studio-tool';
-export { ReadElfTool } from './readelf-tool';
-export { RustFmtTool } from './rustfmt-tool';
-export { StringsTool } from './strings-tool';
-export { x86to6502Tool } from './x86to6502-tool';
+import { BaseTool } from './base-tool';
+
+export class RustFmtTool extends BaseTool {
+    static get key() { return 'rustfmt-tool'; }
+
+    convertResult(result, inputFilepath, exeDir) {
+        // Rustfmt outputs files to stdout with the format
+        // <source>
+        //
+        // { formatted code }
+        // To get the correct right piece of code we want to remove the
+        // first two lines
+        result.stdout = result.stdout.split('\n').slice(2).join('\n');
+        return super.convertResult(result, inputFilepath, exeDir);
+    }
+}


### PR DESCRIPTION
* Rustfmt for Rust
* Modify amazon config to include rustfmt with tools installed by infra
* Tag rustfmt version in amazon.properties

<!-- THIS COMMENT IS INVISIBLE IN THE FINAL PR, BUT FEEL FREE TO REMOVE IT
Thanks for taking the time to improve CE. We really appreciate it.
  Before opening the PR, please make sure that the tests & linter pass their checks,
  by running `make check`.
  In the best case scenario, you are also adding tests to back up your changes,
  but don't sweat it if you don't. We can discuss them at a later date.
Feel free to append your name to the CONTRIBUTORS.md file
Thanks again, we really appreciate this!
-->
